### PR TITLE
Update jdk-12 tag to jdk-12-rc to prepare for use by health-apis-base-upgrader.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 
 Spring Boot application base Docker images.
 
+While jdk-8 can be built we do not use jdk < 12 at this time so at this point only performing release candidate `health-apis-base-upgrader` testing on 12+ builds.
+
 ## Supported Builds
 The following builds are supported.
 - Java 8 (`jdk-8`)
-- Java 12 (`jdk-12`)
+- Java 12 (`jdk-12-rc`)
 
 ## Build Process
 Run `build.sh [8|12]` to generate images. Omit version to build all supported images.
 
-Tags will be appended with _-$VERSION_ (e.g. `jdk-12-1.1.0-SNAPSHOT`). This is done primarily to prevent Jenkins from using a pre-release image to build any applications.
+Tags will be appended with _-$VERSION_ (e.g. `jdk-12-rc-1.1.0-SNAPSHOT`). This is done primarily to prevent Jenkins from using a pre-release image to build any applications.
 
 Upon release, images will be retagged to remove _-$VERSION_ and pushed to Docker Hub.

--- a/build.sh
+++ b/build.sh
@@ -7,11 +7,15 @@ RELEASE=${RELEASE:-false}
 REPOSITORY=vasdvp/health-apis-spring-boot-application-base
 VERSION=${VERSION:-$(cat $BASEDIR/VERSION)}
 
+#
+# NOTE: we do not use jdk < 12 at this time so at this point only
+# performing release candidate health-apis-base-upgrader testing on 12+ builds.
+#
 do_build() {
   local java_version=$1
   case "$java_version" in
     8) local tags=(jdk-8) ;;
-    12) local tags=(jdk-12) ;;
+    12) local tags=(jdk-12-rc) ;;
     *) echo "Unknown Java version: $java_version. Supported versions are 8 and 12." && exit 1 ;;
   esac
   docker build \


### PR DESCRIPTION
NOTE: this PR is coupled with DEVOPS-361 to support canary build portion of https://vasdvp.atlassian.net/wiki/spaces/APIMO/pages/976748545/Rebuilding+Applications+to+keep+up+to+date+with+Vulnerability+Patches

I added everyone I thought was necessary for review, but please feel free to ping me to add more reviewers if I missed anyone.