### PR TITLE
Entry point now exec's Java 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,4 +27,4 @@ then
 fi
 
 echo ============================================================
-java -jar $(find .  -type f -name "$AWS_APP_NAME-*.jar" | head -1)
+exec java -jar $(find .  -type f -name "$AWS_APP_NAME-*.jar" | head -1) $@


### PR DESCRIPTION
and can accept additional command line arguments to help with local testing.

It's not the most convenient, but this can be used to package an application, e.g. fall-risk, in a docker and run it locally:

```
mvn deploy   \
  -DskipTests   \
  -Dexec.skip=true \
  -Dsentinel.skipLaunch=true  \
  -P'!standard'   -Pdocker -Prelease   \
  -Ddocker.skip.push=true   \
  -Dmaven.deploy.skip=true   \
  -Ddocker.username=$DOCKER_USERNAME   \
  -Ddocker.password="$DOCKER_PASSWORD" \
  -Ddocker.baseVersion=jdk-12-rc-1.0.7-SNAPSHOT

docker run -d -p 8070:8070 \
  --rm vasdvp/health-apis-fall-risk:latest \
  --spring.datasource.password='<YourStrong!Passw0rd>'  \
  --spring.datasource.username=SA \
  --spring.datasource.url='jdbc:sqlserver://docker.for.mac.localhost:1433;database=dq;sendStringParametersAsUnicode=false'
```